### PR TITLE
Allow custom args in flutter build web, remove deprecated renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+
+## 0.0.2
+
+* Added support for passing custom arguments to `flutter build web` in `flutter_web_fastify`.
+* Users can now specify additional build parameters dynamically.
+    * **Examples:** 
+        * flutter pub run flutter_web_fastify **--wasm**
+        * flutter pub run flutter_web_fastify **--web-renderer html**
+* **Removed deprecated `--web-renderer=html`** from the default build command, following Flutter's deprecation notice ([Flutter Docs](https://docs.flutter.dev/to/web-html-renderer-deprecation)).
+
+## 0.0.1
+
+* Initial release of `flutter_web_fastify`.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,20 @@
 # flutter_web_fastify
 
-- first build all
- dart pub run build_runner build
- dart run resource_importer
+- First build all
+  ```sh
+  dart pub run build_runner build
+  dart run resource_importer
+  ```
 
-- command
-flutter pub run flutter_web_fastify
+- Command
+  ```sh
+  flutter pub run flutter_web_fastify
+  ```
+
+- Command Line Examples
+  ```sh
+  flutter pub run flutter_web_fastify --wasm
+  ```
+  ```sh
+  flutter pub run flutter_web_fastify --web-renderer html
+  ```

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,7 +10,7 @@ import 'package:string_splitter/string_splitter.dart';
 Future<void> initFastify(List<String> arguments) async {
   verifyIsWebProject();
 
-  await buildFlutterWeb();
+  await buildFlutterWeb(arguments);
 
   await buildChunks();
 
@@ -27,11 +27,12 @@ void verifyIsWebProject() {
   }
 }
 
-Future<void> buildFlutterWeb() async {
+Future<void> buildFlutterWeb(List<String> arguments) async {
   final shell = Shell();
 
+  final args = arguments.join(' ');
   await shell.run('''
-  flutter build web --release --web-renderer html
+  flutter build web --release $args
   ''');
 
   print('create flutter web build');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,13 +1,13 @@
 name: flutter_web_fastify
 description: It is a simple package but it helps you improve the loading times of flutter web
-version: 0.0.1
+version: 0.0.2
 maintainer: Brian Salvattore (@briansalvattore)
 homepage: https://github.com/briansalvattore/flutter_web_fastify
 repository: https://github.com/briansalvattore/flutter_web_fastify
 issue_tracker: https://github.com/briansalvattore/flutter_web_fastify/issues
 
 environment:
-  sdk: '>=2.18.2 <3.0.0'
+  sdk: ">=2.18.2 <3.0.0"
 
 dependencies:
   process_run: 0.13.0
@@ -20,10 +20,10 @@ dev_dependencies:
 
   build_runner: 2.3.3
   build_version: 2.1.1
-  resource_importer: 0.1.0+1	
+  resource_importer: 0.1.0+1
 
 resource_importer:
   resources:
     get_chunks:
-      path: 'lib/templates/get_chunks.js'
+      path: "lib/templates/get_chunks.js"
       type: String


### PR DESCRIPTION
## 📢 Summary
This PR introduces support for passing custom arguments to `flutter build web` in `flutter_web_fastify`. Additionally, it removes the deprecated `--web-renderer=html` to comply with Flutter's latest guidelines.

---

## 🔥 Reason for the Change
- **Customization:** Users can now specify additional build parameters dynamically.
- **Deprecation Compliance:** The `--web-renderer=html` option has been officially deprecated by Flutter ([Flutter Docs](https://docs.flutter.dev/to/web-html-renderer-deprecation)).
![CleanShot 2025-02-10 at 12 45 13@2x](https://github.com/user-attachments/assets/3de90236-0fa6-4e30-81d6-78f1c3e4955c)

---

## 🛠️ Changes
### ✅ Added
- Support for passing custom arguments to `flutter build web`.
- Users can now specify additional parameters, such as:
  ```sh
  flutter pub run flutter_web_fastify --wasm
  ```
  ```sh
  flutter pub run flutter_web_fastify --web-renderer html
  ```